### PR TITLE
Send SMS notification after POS invoice payment

### DIFF
--- a/app/Http/Controllers/SellPosController.php
+++ b/app/Http/Controllers/SellPosController.php
@@ -593,6 +593,7 @@ class SellPosController extends Controller
 
                     //Auto send notification
                     $whatsapp_link = $this->notificationUtil->autoSendNotification($business_id, 'new_sale', $transaction, $transaction->contact);
+                    $this->notificationUtil->sendInvoicePaymentSms($transaction);
 
                     // zatca instant sync if status final type sell
                     if($transaction->type == 'sell'){


### PR DESCRIPTION
## Summary
- add a NotificationUtil helper that builds invoice payment SMS content and pushes it through the provided SMS gateway
- trigger the custom SMS notification whenever a POS sale is finalized

## Testing
- php -l app/Utils/NotificationUtil.php
- php -l app/Http/Controllers/SellPosController.php

------
https://chatgpt.com/codex/tasks/task_e_68e66ff86594832cbe5fa42e3be9bed6